### PR TITLE
Merge upstream updates up to  8.x-1.0-rc2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,12 @@
   "type": "drupal-module",
   "description": "Standards compliant HTML filter written in PHP",
   "homepage": "https://www.drupal.org/project/htmlpurifier",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "support": {
     "issues": "https://www.drupal.org/project/issues/htmlpurifier"
   },
   "require": {
+    "php": ">=7.1",
     "ezyang/htmlpurifier": "^4.10"
   }
 }

--- a/htmlpurifier.info.yml
+++ b/htmlpurifier.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Filter that removes malicious HTML and ensures standards compliant output.'
 package: Filter
 core: 8.x
+core_version_requirement: ^8 || ^9
+php: 7.1

--- a/src/Plugin/Filter/HtmlPurifierFilter.php
+++ b/src/Plugin/Filter/HtmlPurifierFilter.php
@@ -101,25 +101,25 @@ class HtmlPurifierFilter extends FilterBase {
   public function settingsFormConfigurationValidate($element, FormStateInterface $form_state) {
     $values = $form_state->getValue('filters');
     if (isset($values['htmlpurifier']['settings']['htmlpurifier_configuration'])) {
+      $this->configErrors = [];
+
+      // HTMLPurifier library uses triger_error() for not valid settings.
+      set_error_handler([$this, 'configErrorHandler']);
+      try {
+        $this->applyPurifierConfig($values['htmlpurifier']['settings']['htmlpurifier_configuration']);
+      }
+      catch (\Exception $ex) {
+        // This could be a malformed YAML or any other exception.
+        $form_state->setError($element, $ex->getMessage());
+      }
+      restore_error_handler();
+
+      if (!empty($this->configErrors)) {
+        foreach ($this->configErrors as $error) {
+          $form_state->setError($element, $error);
+        }
         $this->configErrors = [];
-
-        // HTMLPurifier library uses triger_error() for not valid settings.
-        set_error_handler([$this, 'configErrorHandler']);
-        try {
-          $this->applyPurifierConfig($values['htmlpurifier']['settings']['htmlpurifier_configuration']);
-        }
-        catch (\Exception $ex) {
-          // This could be a malformed YAML or any other exception.
-          $form_state->setError($element, $ex->getMessage());
-        }
-        restore_error_handler();
-
-        if (!empty($this->configErrors)) {
-          foreach ($this->configErrors as $error) {
-            $form_state->setError($element, $error);
-          }
-          $this->configErrors = [];
-        }
+      }
     }
   }
 

--- a/tests/src/Kernel/HtmlPurifierFilterTest.php
+++ b/tests/src/Kernel/HtmlPurifierFilterTest.php
@@ -7,6 +7,11 @@ use Drupal\Core\Form\FormState;
 use Drupal\filter\FilterPluginCollection;
 use Drupal\KernelTests\KernelTestBase;
 
+/**
+ * Tests htmlpurifier filter.
+ *
+ * @group HtmlPurifier
+ */
 class HtmlPurifierFilterTest extends KernelTestBase {
 
   /**
@@ -21,7 +26,7 @@ class HtmlPurifierFilterTest extends KernelTestBase {
    */
   protected $filter;
 
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $manager = $this->container->get('plugin.manager.filter');
@@ -57,9 +62,14 @@ class HtmlPurifierFilterTest extends KernelTestBase {
   /**
    * Test configuration validation for the filter settings form.
    *
+   * @param string $configuration
+   *   The HTMLPurifier configuration.
+   * @param string[] $expected_errors
+   *   The expected errors.
+   *
    * @dataProvider providerTestConfigurationValidation
    */
-  public function testConfigurationValidation($configuration, $expected_errors) {
+  public function testConfigurationValidation(string $configuration, array $expected_errors) {
     $element = [
       '#parents' => [
         'filters',
@@ -76,10 +86,10 @@ class HtmlPurifierFilterTest extends KernelTestBase {
     $errors = $form_state->getErrors();
     if (!empty($expected_errors)) {
       $this->assertNotEmpty($errors);
-      $this->assertStringStartsWith( $expected_errors[0], array_values($errors)[0]);
+      $this->assertStringContainsString($expected_errors[0], array_values($errors)[0]);
     }
     else {
-      $this->assertSame($expected_errors,  $errors);
+      $this->assertSame($expected_errors, $errors);
     }
   }
 
@@ -102,7 +112,7 @@ class HtmlPurifierFilterTest extends KernelTestBase {
       ],
       'malformed yaml' => [
         str_replace('RemoveEmpty: false', 'UnexpectedString', $default_configuration),
-        ['Unable to parse'],
+        ['pars'],
       ],
     ];
   }


### PR DESCRIPTION
Updates to 8.x-1.0-rc2 and then merges our patches. Here is the command history for reference:

```
$ git remote -v
drupal  git@git.drupal.org:project/htmlpurifier.git (fetch)
drupal  git@git.drupal.org:project/htmlpurifier.git (push)
origin  git@github.com:nbc-bravo/drupal-htmlpurifier.git (fetch)
origin  git@github.com:nbc-bravo/drupal-htmlpurifier.git (push)
$ git checkout 8.x-1.0-rc2
$ git merge patched
$ git checkout -b htmlpurifier-update-8.x-1.0-rc2
$ git push origin htmlpurifier-update-8.x-1.0-rc2
```